### PR TITLE
Remove the apticron package.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ ROLE_INDEPENENT_USEFULL_PACKAGES:
   - git
   - screen
   - build-essential
-  - apticron
   - apt-file
   - links
   - tree
@@ -19,6 +18,3 @@ ROLE_INDEPENENT_USEFULL_PACKAGES:
   - libxml2-dev
   - libxslt1-dev
   - python-dev
-
-# Email to send messages about unattended upgrades to
-UNATTENED_UPGRADES_ERRORS_RELAY_TO: root


### PR DESCRIPTION
It is unneeded for unattended upgrades and doesn't do anything useful for us, yet it creates lots of useless emails.

While we are here, also remove the `UNATTENED_UPGRADES_ERRORS_RELAY_TO` setting, which isn't referenced anywhere.