### PR TITLE
Add `unzip` package as a useful package.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,4 @@ ROLE_INDEPENENT_USEFULL_PACKAGES:
   - libxml2-dev
   - libxslt1-dev
   - python-dev
+  - unzip


### PR DESCRIPTION
Files downloaded from Hashicorp are in zip format, and Ansible needs unzip for those.